### PR TITLE
fixed arrowhead alignment

### DIFF
--- a/src/Components/LetterEncoding/LetterEncoding.js
+++ b/src/Components/LetterEncoding/LetterEncoding.js
@@ -64,7 +64,7 @@ class LetterEncoding extends Component {
                 <svg xmlns="http://www.w3.org/2000/svg" width="110" height="25">
                     <defs>
                         <marker id="arrowhead" refX="10" refY="10" markerUnits="userSpaceOnUse" 
-                            markerWidth="12" markerHeight="20">
+                            markerWidth="12" markerHeight="20" orient="auto">
                             <polyline points="0,0 10,10, 0,20" style={{fill:"none",stroke:"black",strokeWidth:3}} />
                         </marker>
                     </defs>


### PR DESCRIPTION
For some reason the arrow svg used in the second part of the new Atbash intro tried to use the marker definition from the (separate) arrow svg used in the first part of the new Atbash intro, so then the arrowhead alignment for the former got messed up. I just made both arrowhead marker definitions the same so there's no problem