### PR TITLE
Accessibility pass-through

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,7 @@ function App() {
                   to='/game'
                   className='button is-large is-family-secondary has-text-weight-bold'
                 >
-                  Let's get started!
+                  Launch the game!
                 </Link>
               </div>
             </section>

--- a/src/Components/AtbashIntro/AtbashIntro.js
+++ b/src/Components/AtbashIntro/AtbashIntro.js
@@ -9,7 +9,7 @@ function AtbashIntro() {
         <section className="container mb-6">
             <div className="columns is-variable is-5">
                 <div className="column is-one-third">
-                    <img src={hieroglyph1} alt="ancient hieroglyphs depicting birds and other things" />
+                    <img src={hieroglyph1} alt="ancient hieroglyphs" />
                 </div>
                 <div className="column">
                     <div className="content"> 
@@ -25,7 +25,7 @@ function AtbashIntro() {
                 </div>
             </div>
             <div className="column is-one-third">
-                <img src={hieroglyph2} alt="more ancient hieroglyphs" className="position-img" />
+                <img src={hieroglyph2} alt="ancient hieroglyphs" className="position-img" />
             </div>
             <div className="columns">
                 <div className="column is-two-thirds">

--- a/src/Components/Caesar/Caesar.js
+++ b/src/Components/Caesar/Caesar.js
@@ -81,7 +81,7 @@ class Caesar extends Component {
                     </div>
                     <div className="columns is-vcentered">
                         <div className="column is-one-quarter">
-                            <img src={caesar} alt="Caesar"/>
+                            <img src={caesar} alt="silhouette of julius caesar"/>
                         </div>
                         <div className="column columns is-centered">
                             <div className="column is-four-fifths">
@@ -100,7 +100,7 @@ class Caesar extends Component {
                             </div>
                         </div>
                         <div className="column is-one-quarter">
-                            <img src={brutus} alt="Brutus"/>
+                            <img src={brutus} alt="silhouette of armored marcus junius brutus"/>
                         </div>
                     </div> 
                     

--- a/src/Components/CaesarWheel/CaesarWheel.js
+++ b/src/Components/CaesarWheel/CaesarWheel.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import outerwheel from './outercipherwheel.png';
 import innerwheel from './innercipherwheel.png';
 import './caesarwheel.css'
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowRight, faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 
 class CaesarWheel extends Component {
     constructor(props) {
@@ -56,7 +58,19 @@ class CaesarWheel extends Component {
         let adjustedX = x - centerX;
         let adjustedY = y - centerY;
         return { adjustedX, adjustedY };
-     }
+    }
+
+    adjustAngle = (adjustAmt) => {
+        let newOffset = this.state.offset + adjustAmt;
+        this.angle += adjustAmt;
+        this.setState({offset: newOffset}); 
+        
+        if (this.props.onOffsetChange) {
+            let caesarOffset = newOffset * 26/360;
+            caesarOffset = Math.round(caesarOffset);
+            this.props.onOffsetChange(caesarOffset);    
+        }
+    }
 
     atanDegrees = (x, y) => {
         return Math.atan2(y, x)*180/Math.PI;
@@ -64,22 +78,41 @@ class CaesarWheel extends Component {
 
     render() {
         return (
-            <div className="container">
-                <img
-                    className="is-block center round cursor"
-                    src={outerwheel}
-                    alt="letters of the alphabet segmented in a ring"
-                    style={{transform: 'rotate(' + this.state.offset + 'deg)'}}
-                    onMouseDown={this.dragMouseDown}
-                    id="outerwheel"
-                />
-                <img
-                    className="is-overlay is-block center round"
-                    src={innerwheel}
-                    alt="letters of the alphabet segmented in a ring"
-                    onMouseDown={e => e.preventDefault()}
-                />
-            </div>
+            <>
+                <div className="container">
+                    <img
+                        className="is-block center round cursor"
+                        src={outerwheel}
+                        alt="letters of the alphabet segmented in a ring"
+                        style={{transform: 'rotate(' + this.state.offset + 'deg)'}}
+                        onMouseDown={this.dragMouseDown}
+                        id="outerwheel"
+                    />
+                    <img
+                        className="is-overlay is-block center round"
+                        src={innerwheel}
+                        alt="letters of the alphabet segmented in a ring"
+                        onMouseDown={e => e.preventDefault()}
+                    />
+                </div>
+
+                <div className='my-3'></div>
+
+                <div className='container'>
+                    <button
+                        className='button is-large is-family-secondary has-text-weight-bold'
+                        onClick={() => this.adjustAngle(-1*360/26) }
+                    >
+                        <FontAwesomeIcon icon={faArrowLeft} />
+                    </button>
+                    <button
+                        className='button is-large is-family-secondary has-text-weight-bold'
+                        onClick={() => this.adjustAngle(360/26) }
+                    >
+                        <FontAwesomeIcon icon={faArrowRight} />
+                    </button>
+                </div>
+            </>
         );
     }
 }

--- a/src/Components/CaesarWheel/CaesarWheel.js
+++ b/src/Components/CaesarWheel/CaesarWheel.js
@@ -68,7 +68,7 @@ class CaesarWheel extends Component {
                 <img
                     className="is-block center round cursor"
                     src={outerwheel}
-                    alt="Outer wheel of the caesar cipher decoder."
+                    alt="letters of the alphabet segmented in a ring"
                     style={{transform: 'rotate(' + this.state.offset + 'deg)'}}
                     onMouseDown={this.dragMouseDown}
                     id="outerwheel"
@@ -76,7 +76,7 @@ class CaesarWheel extends Component {
                 <img
                     className="is-overlay is-block center round"
                     src={innerwheel}
-                    alt="Inner wheel of the caesar cipher decoder."
+                    alt="letters of the alphabet segmented in a ring"
                     onMouseDown={e => e.preventDefault()}
                 />
             </div>

--- a/src/Components/CaesarWheel/CaesarWheel.js
+++ b/src/Components/CaesarWheel/CaesarWheel.js
@@ -103,13 +103,13 @@ class CaesarWheel extends Component {
                         className='button is-large is-family-secondary has-text-weight-bold'
                         onClick={() => this.adjustAngle(-1*360/26) }
                     >
-                        <FontAwesomeIcon icon={faArrowLeft} />
+                        <FontAwesomeIcon icon={faArrowLeft} alt='left arrow' />
                     </button>
                     <button
                         className='button is-large is-family-secondary has-text-weight-bold'
                         onClick={() => this.adjustAngle(360/26) }
                     >
-                        <FontAwesomeIcon icon={faArrowRight} />
+                        <FontAwesomeIcon icon={faArrowRight} alt='right arrow' />
                     </button>
                 </div>
             </>

--- a/src/Components/DecodingOptions/DecodingOptions.js
+++ b/src/Components/DecodingOptions/DecodingOptions.js
@@ -67,7 +67,7 @@ class DecodingOptions extends Component {
                         or crack the cipher altogether! (This is what was used to break the Enigma Machine's encryption in WWII!)
                     </p>
                     <p className="is-size-4 mt-5 mb-1">It might be tedious to decode messages on your own, but watch how fast a computer can crack this!</p>
-                    <button className="button is-large is-family-secondary has-text-weight-bold">Go</button>
+                    <button className="button is-large is-family-secondary has-text-weight-bold">Crack the message!</button>
                 </Anime>
             );
         } else if (this.props.animateIn) {
@@ -99,7 +99,7 @@ class DecodingOptions extends Component {
                             or crack the cipher altogether! (This is what was used to break the Enigma Machine's encryption in WWII!)
                         </p>
                         <p className="is-size-4 mt-5 mb-1">It might be tedious to decode messages on your own, but watch how fast a computer can crack this!</p>
-                        <button className="button is-large is-family-secondary has-text-weight-bold">Go</button>
+                        <button className="button is-large is-family-secondary has-text-weight-bold">Crack the message!</button>
                     </Anime>
                 </div>
             );
@@ -131,7 +131,7 @@ class DecodingOptions extends Component {
                         or crack the cipher altogether! (This is what was used to break the Enigma Machine's encryption in WWII!)
                     </p>
                     <p className="is-size-4 mt-5 mb-1">It might be tedious to decode messages on your own, but watch how fast a computer can crack this!</p>
-                    <button className="button button-hover-border is-large is-family-secondary has-text-weight-bold" onClick={this.startCorrectDecodingClick}>Go</button>
+                    <button className="button button-hover-border is-large is-family-secondary has-text-weight-bold" onClick={this.startCorrectDecodingClick}>Crack the message!</button>
                 </Anime>
             );
         }

--- a/src/Components/LetterBox.js
+++ b/src/Components/LetterBox.js
@@ -14,9 +14,9 @@ const CAPITAL_Z = 90;
 function Letter ({ key, char }) {
     return(
     <div className="control" key={key}>
-    <button className="button is-static is-medium is-family-secondary has-text-weight-bold" style={{width:58+'px'}}>
-        <p>{char}</p>
-    </button>
+        <div className="button is-static is-medium is-family-secondary has-text-weight-bold" style={{width:58+'px'}}>
+            <p>{char}</p>
+        </div>
     </div>
     )
 }

--- a/src/Components/LetterEncoding/LetterEncoding.js
+++ b/src/Components/LetterEncoding/LetterEncoding.js
@@ -3,9 +3,13 @@ import Anime, { anime } from 'react-anime'
 
     function LetterButton(props) {
         return (
-            <div className="button button-height is-static has-text-weight-bold is-family-secondary px-4 is-size-2"
+            <div
+                className="button button-height is-static has-text-weight-bold is-family-secondary px-4 is-size-2"
                 style={props.shouldHandleMouseEnter ? {pointerEvents: "auto"} : {}}
-                onMouseEnter={props.shouldHandleMouseEnter ? props.handleMouseEnter : null}>
+                tabIndex={0}
+                onMouseEnter={props.shouldHandleMouseEnter ? props.handleMouseEnter : null}
+                onFocus={props.shouldHandleMouseEnter ? props.handleMouseEnter : null}
+            >
                 {props.children}
             </div>
         );

--- a/src/Components/LetterEncoding/LetterEncoding.js
+++ b/src/Components/LetterEncoding/LetterEncoding.js
@@ -3,11 +3,11 @@ import Anime, { anime } from 'react-anime'
 
     function LetterButton(props) {
         return (
-            <button className="button button-height is-static has-text-weight-bold is-family-secondary px-4 is-size-2"
+            <div className="button button-height is-static has-text-weight-bold is-family-secondary px-4 is-size-2"
                 style={props.shouldHandleMouseEnter ? {pointerEvents: "auto"} : {}}
                 onMouseEnter={props.shouldHandleMouseEnter ? props.handleMouseEnter : null}>
                 {props.children}
-            </button>
+            </div>
         );
     }
 

--- a/src/Components/Title/Blackbox.js
+++ b/src/Components/Title/Blackbox.js
@@ -112,7 +112,7 @@ function Page2(props){
         (which we’ll just show as a black box) on the message, 
         and only the recipient who is given the original key can undo the math.  
       </div>
-      <img src="/alice_bob.svg" className="img_alice_bob" style={{position:'absolute',top:'60px',left:'0',right:'0',margin:'auto', width: '650px', height: 'auto'}} alt="Alice & Bob"></img>
+      <img src="/alice_bob.svg" className="img_alice_bob" style={{position:'absolute',top:'60px',left:'0',right:'0',margin:'auto', width: '650px', height: 'auto'}} alt="people sending messages over the internet"></img>
       </div>
     </React.Fragment>
   )
@@ -238,7 +238,7 @@ function Page6(props){
   return(
     <React.Fragment>
       <div className="blackbox_container">
-      <img src="/alice_bob.svg" className="img_alice_bob" style={{position:'absolute',top:'90px',left:'0',right:'0',margin:'auto', width: '650px', height: 'auto'}} alt="Alice & Bob"></img>
+      <img src="/alice_bob.svg" className="img_alice_bob" style={{position:'absolute',top:'90px',left:'0',right:'0',margin:'auto', width: '650px', height: 'auto'}} alt="people sending messages over the internet"></img>
       <FontAwesomeIcon icon={faKey} size="3x" color="#FFB800" style={{position:'absolute', left:'20%', top:'80px', height: '600px',transform: 'rotate(225deg)'}} />
       <FontAwesomeIcon icon={faKey} size="3x" color="#FFB800" style={{position:'absolute', left:'75%', top:'60px', height: '600px',transform: 'rotate(225deg)'}} />
       <div className="text_narrow small_font" style={{position:'absolute',top:'120px',left:'180px'}}>

--- a/src/Components/Title/Blackbox.js
+++ b/src/Components/Title/Blackbox.js
@@ -83,8 +83,8 @@ function Page1(props){
   return(
       <React.Fragment>
           <div className="blackbox_container">
-            <FontAwesomeIcon icon={faKey} size="6x" color="#FFB800" style={{position:'absolute', left:'400px', top:'100px', height: '600px',transform: 'rotate(225deg)'}} />
-            <FontAwesomeIcon icon={faArchive} size="9x" color="#000000" style={{position:'absolute', left:'750px', top:'100px', height: '600px'}} />
+            <FontAwesomeIcon icon={faKey} alt='key' size="6x" color="#FFB800" style={{position:'absolute', left:'400px', top:'100px', height: '600px',transform: 'rotate(225deg)'}} />
+            <FontAwesomeIcon icon={faArchive} alt='banker box' size="9x" color="#000000" style={{position:'absolute', left:'750px', top:'100px', height: '600px'}} />
             <div className="mid_font" style={{position:'absolute',top:'200px',left:'250px'}}>
               But how can ciphers get more complicated??
             </div>
@@ -123,9 +123,9 @@ function Page3(props){
   return(
     <React.Fragment>
       <div className="blackbox_container">
-        <FontAwesomeIcon icon={faKey} size="6x" color="#FFB800" style={{position:'absolute', left:'30%', top:'0px', height: '600px',transform: 'rotate(225deg)'}} />
-        <FontAwesomeIcon icon={faArchive} size="9x" color="#000000" style={{position:'absolute', left:'60%', top:'100px', height: '600px'}} />
-        <FontAwesomeIcon icon={faEnvelopeOpen} size="6x" color="#FFB800" style={{position:'absolute', left:'30%', top:'200px', height: '600px'}} />
+        <FontAwesomeIcon icon={faKey} alt='key' size="6x" color="#FFB800" style={{position:'absolute', left:'30%', top:'0px', height: '600px',transform: 'rotate(225deg)'}} />
+        <FontAwesomeIcon icon={faArchive} alt='banker box' size="9x" color="#000000" style={{position:'absolute', left:'60%', top:'100px', height: '600px'}} />
+        <FontAwesomeIcon icon={faEnvelopeOpen} alt='open envelope' size="6x" color="#FFB800" style={{position:'absolute', left:'30%', top:'200px', height: '600px'}} />
         <div className="text_narrow small_font" style={{position:'absolute',top:'150px',left:'0',right:'0',margin:'auto'}}>
           The black box takes in our secret message and a secret key,
         </div>
@@ -135,7 +135,7 @@ function Page3(props){
           translateX="200px"
           opacity={['50%','100%', '0%']}
         >
-          <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'40%', top:'290px', transform: 'rotate(30deg)'}}></FontAwesomeIcon>             
+          <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'40%', top:'290px', transform: 'rotate(30deg)'}}></FontAwesomeIcon>             
         </Anime>
         <Anime easing="linear" duration="900"
           loop={true}
@@ -143,7 +143,7 @@ function Page3(props){
           translateX="200px"
           opacity={['50%','100%', '0%']}
         >
-          <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'40%', top:'470px', transform: 'rotate(-30deg)'}}></FontAwesomeIcon>             
+          <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'40%', top:'470px', transform: 'rotate(-30deg)'}}></FontAwesomeIcon>             
         </Anime>
       </div>
     </React.Fragment>
@@ -155,10 +155,10 @@ function Page4(props){
   return(
       <React.Fragment>
       <div className="blackbox_container">
-        <FontAwesomeIcon icon={faKey} size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'0px', height: '600px',transform: 'rotate(225deg)'}} />
-        <FontAwesomeIcon icon={faArchive} size="9x" color="#000000" style={{position:'absolute', left:'45%', top:'100px', height: '600px'}} />
-        <FontAwesomeIcon icon={faEnvelopeOpen} size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'200px', height: '600px'}} />
-        <FontAwesomeIcon icon={faFileArchive} size="6x" color="#FFB800" style={{position:'absolute', left:'72%', top:'100px', height: '600px'}} />
+        <FontAwesomeIcon icon={faKey} alt='key' size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'0px', height: '600px',transform: 'rotate(225deg)'}} />
+        <FontAwesomeIcon icon={faArchive} alt='bankers box' size="9x" color="#000000" style={{position:'absolute', left:'45%', top:'100px', height: '600px'}} />
+        <FontAwesomeIcon icon={faEnvelopeOpen} alt='open envelope' size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'200px', height: '600px'}} />
+        <FontAwesomeIcon icon={faFileArchive} alt='zipped file' size="6x" color="#FFB800" style={{position:'absolute', left:'72%', top:'100px', height: '600px'}} />
         <div className="text_narrow small_font" style={{position:'absolute',top:'150px',left:'0',right:'0',margin:'auto'}}>
           And spits out an encrypted message!
         </div>
@@ -168,7 +168,7 @@ function Page4(props){
           translateX="160px"
           opacity={['50%','100%', '0%']}
         >
-          <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'29%', top:'290px', transform: 'rotate(30deg)'}}></FontAwesomeIcon>             
+          <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'29%', top:'290px', transform: 'rotate(30deg)'}}></FontAwesomeIcon>             
         </Anime>
         <Anime easing="linear" duration="900"
           loop={true}
@@ -176,7 +176,7 @@ function Page4(props){
           translateX="160px"
           opacity={['50%','100%', '0%']}
         >
-          <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'29%', top:'470px', transform: 'rotate(-30deg)'}}></FontAwesomeIcon>             
+          <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'29%', top:'470px', transform: 'rotate(-30deg)'}}></FontAwesomeIcon>             
         </Anime>
         <Anime easing="linear" duration="900"
           loop={true}
@@ -184,7 +184,7 @@ function Page4(props){
           translateX="150px"
           opacity={['50%','100%', '0%']}
         >
-          <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'56%', top:'390px'}}></FontAwesomeIcon>             
+          <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'56%', top:'390px'}}></FontAwesomeIcon>             
         </Anime>
       </div>
       </React.Fragment>
@@ -196,10 +196,10 @@ function Page5(props){
   return(
     <React.Fragment>
     <div className="blackbox_container">
-    <FontAwesomeIcon icon={faKey} size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'0px', height: '600px',transform: 'rotate(225deg)'}} />
-    <FontAwesomeIcon icon={faArchive} size="9x" color="#000000" style={{position:'absolute', left:'45%', top:'100px', height: '600px'}} />
-    <FontAwesomeIcon icon={faEnvelopeOpen} size="6x" color="#FFB800" style={{position:'absolute', left:'72%', top:'100px', height: '600px'}} />
-    <FontAwesomeIcon icon={faFileArchive} size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'200px', height: '600px'}} />      
+    <FontAwesomeIcon icon={faKey} alt='key' size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'0px', height: '600px',transform: 'rotate(225deg)'}} />
+    <FontAwesomeIcon icon={faArchive} alt='zipped file' size="9x" color="#000000" style={{position:'absolute', left:'45%', top:'100px', height: '600px'}} />
+    <FontAwesomeIcon icon={faEnvelopeOpen} alt='open envelope' size="6x" color="#FFB800" style={{position:'absolute', left:'72%', top:'100px', height: '600px'}} />
+    <FontAwesomeIcon icon={faFileArchive} alt='zipped file' size="6x" color="#FFB800" style={{position:'absolute', left:'20%', top:'200px', height: '600px'}} />      
     <div className="text_narrow small_font" style={{position:'absolute',top:'120px',left:'0',right:'0',margin:'auto'}}>
       The magic happens when you give the black box *the same key and the encrypted message* 
       -- That’s the only way to get the original message back!
@@ -210,7 +210,7 @@ function Page5(props){
       translateX="160px"
       opacity={['50%','100%', '0%']}
     >
-      <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'29%', top:'290px', transform: 'rotate(30deg)'}}></FontAwesomeIcon>             
+      <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'29%', top:'290px', transform: 'rotate(30deg)'}}></FontAwesomeIcon>             
     </Anime>
     <Anime easing="linear" duration="900"
       loop={true}
@@ -218,7 +218,7 @@ function Page5(props){
       translateX="160px"
       opacity={['50%','100%', '0%']}
     >
-      <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'29%', top:'470px', transform: 'rotate(-30deg)'}}></FontAwesomeIcon>             
+      <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'29%', top:'470px', transform: 'rotate(-30deg)'}}></FontAwesomeIcon>             
     </Anime>
     <Anime easing="linear" duration="900"
       loop={true}
@@ -226,7 +226,7 @@ function Page5(props){
       translateX="150px"
       opacity={['50%','100%', '0%']}
     >
-      <FontAwesomeIcon icon={faArrowRight} size="2x" color="#0" style={{position:'absolute', left:'56%', top:'390px'}}></FontAwesomeIcon>             
+      <FontAwesomeIcon icon={faArrowRight} alt='right arrow' size="2x" color="#0" style={{position:'absolute', left:'56%', top:'390px'}}></FontAwesomeIcon>             
     </Anime>
     </div>
     </React.Fragment>
@@ -239,8 +239,8 @@ function Page6(props){
     <React.Fragment>
       <div className="blackbox_container">
       <img src="/alice_bob.svg" className="img_alice_bob" style={{position:'absolute',top:'90px',left:'0',right:'0',margin:'auto', width: '650px', height: 'auto'}} alt="people sending messages over the internet"></img>
-      <FontAwesomeIcon icon={faKey} size="3x" color="#FFB800" style={{position:'absolute', left:'20%', top:'80px', height: '600px',transform: 'rotate(225deg)'}} />
-      <FontAwesomeIcon icon={faKey} size="3x" color="#FFB800" style={{position:'absolute', left:'75%', top:'60px', height: '600px',transform: 'rotate(225deg)'}} />
+      <FontAwesomeIcon icon={faKey} alt='key' size="3x" color="#FFB800" style={{position:'absolute', left:'20%', top:'80px', height: '600px',transform: 'rotate(225deg)'}} />
+      <FontAwesomeIcon icon={faKey} alt='key' size="3x" color="#FFB800" style={{position:'absolute', left:'75%', top:'60px', height: '600px',transform: 'rotate(225deg)'}} />
       <div className="text_narrow small_font" style={{position:'absolute',top:'120px',left:'180px'}}>
           So anyone without the key will just see
       </div>
@@ -265,7 +265,7 @@ return(
         loop={true}
         opacity={['0%','100%','100%','0%','0%','0%','0%','0%']}
       >
-        <FontAwesomeIcon icon={faKey} size="10x" color="#FFB800" style={{position:'absolute', left:'0', right:'0', margin:'auto',top:'350px',transform: 'rotate(225deg)'}}></FontAwesomeIcon>             
+        <FontAwesomeIcon icon={faKey} alt='key' size="10x" color="#FFB800" style={{position:'absolute', left:'0', right:'0', margin:'auto',top:'350px',transform: 'rotate(225deg)'}}></FontAwesomeIcon>             
       </Anime>
       <Anime easing="linear" duration="6000"
         loop={true}

--- a/src/Components/Title/Closing.js
+++ b/src/Components/Title/Closing.js
@@ -27,7 +27,7 @@ class Closing extends React.Component {
             <div className="column">
                 <div className="columns is-vcenterd container">
                   <div className="column is-one-third">
-                    <img src="/enigma.png" alt="Enigma machine" className="img"/>
+                    <img src="/enigma.png" alt="enigma machine" className="img"/>
                   </div>
                   <div className="subtitle is-size-4 content-custom column is-two-thirds container">
                       Fun fact:
@@ -42,7 +42,7 @@ class Closing extends React.Component {
                       Any salad can be a caesar salad if you put it through the March of Ides!
                   </div>
                   <div className="column is-one-third">
-                    <img src="/caesar_salad.jpg" alt="salad" className="img"/>
+                    <img src="/caesar_salad.jpg" alt="caesar salad" className="img" />
                   </div>
                 </div>
               </div>

--- a/src/Components/Title/Title.js
+++ b/src/Components/Title/Title.js
@@ -45,7 +45,7 @@ class Title extends Component {
             <div className="container">
               <div className= "columns is-vcentered">
                 <div className="column is-relative">
-                  <img src={laptop} alt="Laptop displaying title"/>
+                  <img src={laptop} alt="laptop typing"/>
                   <div className="is-overlay is-family-monospace position-text">
                     <div className="is-inline-block">
                       <div className="typing-animation typing-title">

--- a/src/Components/VertNav/VertNav.js
+++ b/src/Components/VertNav/VertNav.js
@@ -29,18 +29,18 @@ export default function VertNav(props) {
   const [ hidden, setHidden ] = useState(true);
 
   const spyContents = props.navLinks.map(id => (
-    <AnchorLink offset={-5} href={`#${id}`}>
+    <AnchorLink offset={-5} href={`#${id}`} tabIndex={10}>
       <FontAwesomeIcon size='2x' icon={faKey} alt='key' />
     </AnchorLink>
   ));
   
   return (
-    <div className={`vnav-container${hidden ? ' vnav-hidden' : ''}`}>
+    <div className={``}>
       <Scrollspy
+        componentTag='nav'
+        className={`vnav ${hidden ? ' vnav-hidden' : ''}`}
         items={props.navLinks}
         currentClassName='current-section'
-        componentTag='nav'
-        className='vnav'
         onUpdate={e => {
           if (!e)
             setHidden(true);

--- a/src/Components/VertNav/VertNav.js
+++ b/src/Components/VertNav/VertNav.js
@@ -30,7 +30,7 @@ export default function VertNav(props) {
 
   const spyContents = props.navLinks.map(id => (
     <AnchorLink offset={-5} href={`#${id}`}>
-      <FontAwesomeIcon size='2x' icon={faKey} />
+      <FontAwesomeIcon size='2x' icon={faKey} alt='key' />
     </AnchorLink>
   ));
   

--- a/src/Components/VertNav/VertNav.js
+++ b/src/Components/VertNav/VertNav.js
@@ -35,24 +35,22 @@ export default function VertNav(props) {
   ));
   
   return (
-    <div className={``}>
-      <Scrollspy
-        componentTag='nav'
-        className={`vnav ${hidden ? ' vnav-hidden' : ''}`}
-        items={props.navLinks}
-        currentClassName='current-section'
-        onUpdate={e => {
-          if (!e)
-            setHidden(true);
-          else {
-            if (props.callbacks && props.callbacks[e.id])
-              props.callbacks[e.id](e);
-            setHidden(false);
-          }
-        }}
-      >
-        {spyContents}
-      </Scrollspy>
-    </div>
+    <Scrollspy
+      componentTag='nav'
+      className={`vnav ${hidden ? ' vnav-hidden' : ''}`}
+      items={props.navLinks}
+      currentClassName='current-section'
+      onUpdate={e => {
+        if (!e)
+          setHidden(true);
+        else {
+          if (props.callbacks && props.callbacks[e.id])
+            props.callbacks[e.id](e);
+          setHidden(false);
+        }
+      }}
+    >
+      {spyContents}
+    </Scrollspy>
   );
 }

--- a/src/Components/VertNav/VertNav.js
+++ b/src/Components/VertNav/VertNav.js
@@ -39,7 +39,7 @@ export default function VertNav(props) {
       <Scrollspy
         items={props.navLinks}
         currentClassName='current-section'
-        componentTag='div'
+        componentTag='nav'
         className='vnav'
         onUpdate={e => {
           if (!e)

--- a/src/Components/VertNav/VertNav.scss
+++ b/src/Components/VertNav/VertNav.scss
@@ -1,19 +1,16 @@
 $vnav-anim-time: .3s;
 
-.vnav-container {
+.vnav-hidden {
+  opacity: 0;
+}
+
+.vnav {
   position: fixed;
   background: none !important;
   left: 0;
   top: 50%;
   transition: opacity $vnav-anim-time ease;
   z-index: 1000;
-}
-
-.vnav-hidden {
-  opacity: 0;
-}
-
-.vnav {
   padding: 1rem;
   transform: translateY(-50%);
   display: flex;

--- a/src/Components/Vigenere/Vigenere.js
+++ b/src/Components/Vigenere/Vigenere.js
@@ -96,7 +96,7 @@ class Vigenere extends Component {
                 <div className="column">
                     <div className="columns is-vcentered">
                         <div className="column is-one-third">
-                            <img src="/vigenere_1.png" alt="caesar cipher encoding example" className="is-3by2"/>
+                            <img src="/vigenere_1.png" alt="shifting the alphabet by 3" className="is-3by2"/>
                         </div>
                         <div className="is-two-thirds is-size-5 content-custom column">
                             So far we’ve seen the ancient caesar cipher and atbash cipher. 
@@ -114,7 +114,7 @@ class Vigenere extends Component {
                             
                         </div>
                         <div className="column is-half">
-                            <img src="/vigenere_2.png" alt="vigenere cipher encoding example"/>
+                            <img src="/vigenere_2.png" alt="demonstration of individual letter shifts"/>
                         </div>
                     </div> 
                     <div className="columns">


### PR DESCRIPTION
This PR handles the issues raised in #35:
- [x] Change all non-clickable elements to not use buttons anymore - causes issues w/ tabbing through page
- [x] Believe we need to change role or tabindex on floating scrollspy nav
- [x] Alt text for images, icons
- [x] Audit hover functionality to be keyboard-usable
- [x] Not sure how animations and staggered content work for screenreaders, should investigate further
- [x] Is it possible to make the wheel accessible at all? Maybe adding buttons or something?
- [x] Rephrase copy & CTAs to be clearer (e.g. instead of a button that says "Go", button says "Play the Game" or something)

### General Accessibility
* Handles the misuse of buttons
* Fixes tab order with respect to the vertical nav
* Alt text for images, icons
* Rephrases CTAs

### Hover functionality is now keyboard-usable

The function that fires `onhover` is now bound to `onfocus` as well.

### CaesarWheel

Adds buttons to the CaesarWheel component.

Closes #35.